### PR TITLE
Remove misplaced anchor tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,6 @@
       </a>
       <section class="ui-section-pricing">
         <div class="ui-layout-container">
-          <a id="pricing">
           <h2>Find your perfect plan</h2>
           <p class="ui-text-intro">Start 7 days free. Then purchase a plan to start emailing like a pro.</p>
           <!-- TOGGLE -->


### PR DESCRIPTION
Verified changes by opening the web page locally and inspecting that the pricing section is fixed.

Removed a misplaced anchor tag that was displacing pricing solutions cards in its parent grid.